### PR TITLE
RDKCOM-5360 RDKBNETWOR-63: Incorrect MAP-T Sharing Ratio and ..

### DIFF
--- a/source/Styles/xb3/jst/DPoE.jst
+++ b/source/Styles/xb3/jst/DPoE.jst
@@ -25,8 +25,11 @@
 </div><!-- end #sub-header -->
 <?% include('includes/nav.jst'); ?>
 <?%
-        $NetworkName = "";
-        $NetworkName = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.RDKB_UIBranding.HelpTip.NetworkName");
+	$NetworkName = "";
+	$NetworkName = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.RDKB_UIBranding.HelpTip.NetworkName");
+	$dhcp_client_interfaces = get_dhcp_client_interfaces();
+	$dhcp_client_interface_v4 = $dhcp_client_interfaces.v4;
+	$dhcp_client_interface_v6 = $dhcp_client_interfaces.v6;
 ?>
 <script type="text/javascript">
 $(document).ready(function() {
@@ -141,7 +144,7 @@ function sec2dhms($sec)
                 <?%
                         //echo getStr("Device.Routing.Router.1.IPv4Forwarding.1.GatewayIPAddress");
                         /* For BWG, we just use the DHCP GW received from upstream as the wan side GW */
-                        echo( getStr("Device.DHCPv4.Client.1.IPRouters"));
+                        echo( getStr($dhcp_client_interface_v4+".IPRouters"));
                 ?>
                 </span>
         </div>
@@ -223,7 +226,7 @@ function sec2dhms($sec)
         </div>
         <div class="form-row ">
 		<span class="readonlyLabel" id="dhcliv6">DHCP Client (IPv6):</span> <span class="value">
-                <?% echo( ("true"==getStr("Device.DHCPv6.Client.1.Enable")) ? "Enabled" : "Disabled");?>
+                <?% echo( ("true"==getStr($dhcp_client_interface_v6+".Enable")) ? "Enabled" : "Disabled");?>
                 </span>
         </div>
         <div class="form-row odd">
@@ -231,7 +234,7 @@ function sec2dhms($sec)
                 <span class="value">
                 <?%
                         $sec = 0;
-                        $sec = getStr("Device.DHCPv4.Client.1.LeaseTimeRemaining");
+                        $sec = getStr($dhcp_client_interface_v4+".LeaseTimeRemaining");
                         $tmp = div_mod($sec, 24*60*60);
                         $day = $tmp[0];
                         $tmp = div_mod($tmp[1], 60*60);

--- a/source/Styles/xb3/jst/connection_status.jst
+++ b/source/Styles/xb3/jst/connection_status.jst
@@ -27,19 +27,22 @@
 <?% include('includes/nav.jst'); ?>
 <?% $ForceDisable = getStr("Device.WiFi.X_RDK-CENTRAL_COM_ForceDisable"); ?>
 <?%
-    $fistDSif = getFirstDownstreamIpInterface();
-    $autoWanEnable= getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_AutowanFeatureSupport");
-    $OperatingChannelBandwidth = "";
-    $RadioNumberOfEntries = getStr("Device.WiFi.RadioNumberOfEntries");
-    if($RadioNumberOfEntries)
-    {
-	for($r=1; $r <= $RadioNumberOfEntries ; $r++)
+	$dhcp_client_interfaces = get_dhcp_client_interfaces();
+	$dhcp_client_interface_v4 = $dhcp_client_interfaces.v4;
+	$dhcp_client_interface_v6 = $dhcp_client_interfaces.v6;
+	$fistDSif = getFirstDownstreamIpInterface();
+	$autoWanEnable= getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_AutowanFeatureSupport");
+	$OperatingChannelBandwidth = "";
+	$RadioNumberOfEntries = getStr("Device.WiFi.RadioNumberOfEntries");
+	if($RadioNumberOfEntries)
 	{
-		$OperatingChannelBandwidth = getStr("Device.WiFi.Radio."+$r+".OperatingFrequencyBand");
-		if($OperatingChannelBandwidth == "6GHz")
-			break;
+		for($r=1; $r <= $RadioNumberOfEntries ; $r++)
+		{
+			$OperatingChannelBandwidth = getStr("Device.WiFi.Radio."+$r+".OperatingFrequencyBand");
+			if($OperatingChannelBandwidth == "6GHz")
+				break;
+		}
 	}
-    }
     // $fistDSif = "Device.IP.Interface.2.";
 	// initial some variable to suppress some error
     $ipv6_local_addr = "";
@@ -433,7 +436,7 @@ if(($allowEthWan=="true") || ($autoWanEnable=="true")) {
                                     echo('<span class="value" id="actautwan">Active Auto WAN');
                                 }
                             }
-                          }          
+                          }
                          ?>
                     </span>
                 </div>
@@ -441,7 +444,7 @@ if(($allowEthWan=="true") || ($autoWanEnable=="true")) {
                     <span class="readonlyLabel" id="wanip4">WAN IP Address (IPv4):</span> <span class="value">
                          <?%
 			$mapT ="";
-			$mapT = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
+			$mapT = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
 			//$mapT = "MAPT";
 			$jsMapEnable="false";
 			$partnerId = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId");
@@ -449,7 +452,7 @@ if(($allowEthWan=="true") || ($autoWanEnable=="true")) {
 			        $jsMapEnable = "true";
 			}
 			if($jsMapEnable == "true")
-				$WANIPv4 = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
+				$WANIPv4 = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
 			else
                         	$WANIPv4 = getStr($fistUSif+"IPv4Address.1.IPAddress");
                           echo( $WANIPv4);
@@ -495,7 +498,7 @@ if(($allowEthWan=="true") || ($autoWanEnable=="true")) {
                       echo("<span class='value' id='act'>Active</span>");
                    }
                    else{
-                      echo("<span class='value' id='inact'>Inactive</span>"); 
+                      echo("<span class='value' id='inact'>Inactive</span>");
                    }
               }
             }
@@ -505,10 +508,10 @@ if(($allowEthWan=="true") || ($autoWanEnable=="true")) {
             $WAN_IP_Address = '';
             $address_style = '';
             if(strpos($partnerId, "sky-") !== false){
-                $isMapT = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
+                $isMapT = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
                 if($isMapT == 'MAPT'){
-		    $WANIPv4 = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
-		    $WANIPv4 += '<span id="shrdMpT_cs"> (Shared using MAP-T)</span>';
+					$WANIPv4 = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
+					$WANIPv4 += '<span id="shrdMpT_cs"> (Shared using MAP-T)</span>';
                     //$WANIPv4Gateway = '-NA-';
                     $WAN_IP_Address = $WANIPv4;
                     $address_style = 'connection_address';
@@ -547,7 +550,7 @@ if(($allowEthWan=="true") || ($autoWanEnable=="true")) {
         <div class="form-row">
           <span class="readonlyLabel" id="dhcpexploc">DHCP Expire Time:</span> <span class="value">
                     <?%
-                    $expire_time = getStr("Device.DHCPv4.Client.1.LeaseTimeRemaining");
+                    $expire_time = getStr($dhcp_client_interface_v4+".LeaseTimeRemaining");
                     echo( sec2dhms($expire_time));
                     ?>
                 </span>

--- a/source/Styles/xb3/jst/device_discovery.jst
+++ b/source/Styles/xb3/jst/device_discovery.jst
@@ -26,13 +26,14 @@
 </div><!-- end #sub-header -->
 <?% include('includes/nav.jst'); ?>
 <?%
-//start by licha
+$dhcp_client_interfaces = get_dhcp_client_interfaces();
+$dhcp_client_interface_v6 = $dhcp_client_interfaces.v6;
 $enableUPnP = getStr("Device.UPnP.Device.UPnPIGD");
 $adPeriod = getStr("Device.UPnP.Device.X_CISCO_COM_IGD_AdvertisementPeriod");
 $timeToLive = getStr("Device.UPnP.Device.X_CISCO_COM_IGD_TTL");
 $enableZero = getStr("Device.X_CISCO_COM_DeviceControl.EnableZeroConfig");
 $mapT ="";
-$mapT = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
+$mapT = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
 $partnerId = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId");
 //$mapT = "MAPT";
 $jsMapEnable="false";

--- a/source/Styles/xb3/jst/dmz.jst
+++ b/source/Styles/xb3/jst/dmz.jst
@@ -37,6 +37,8 @@ else{
 	$idadv="connhom1";
 	$idadv2 = "dmzmess";
 }
+$dhcp_client_interfaces = get_dhcp_client_interfaces();
+$dhcp_client_interface_v6 = $dhcp_client_interfaces.v6;
 $enableDMZ		= getStr("Device.NAT.X_CISCO_COM_DMZ.Enable");
 $host   		= getStr("Device.NAT.X_CISCO_COM_DMZ.InternalIP");
 $hostv6 		= getStr("Device.NAT.X_CISCO_COM_DMZ.IPv6Host");
@@ -46,7 +48,7 @@ $IPv6Prefix     = getStr("Device.IP.Interface.1.IPv6Prefix.1.Prefix");
 $beginAddr      = getStr("Device.DHCPv4.Server.Pool.1.MinAddress");
 $endAddr        = getStr("Device.DHCPv4.Server.Pool.1.MaxAddress");
 $mapT ="";
-$mapT = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
+$mapT = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
 $partnerId = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId");
 $jsMapEnable="false";
 if(($mapT=="MAPT") && (strpos($partnerId, "sky-") === false)){

--- a/source/Styles/xb3/jst/includes/userbar.jst
+++ b/source/Styles/xb3/jst/includes/userbar.jst
@@ -49,6 +49,8 @@
 	    $MoCA = false;
 	    $battery = false;
 	}
+	$dhcp_client_interfaces = get_dhcp_client_interfaces();
+	$dhcp_client_interface_v6 = $dhcp_client_interfaces.v6;
 ?>
 <script type="text/javascript">
 setTimeout(function(){
@@ -150,7 +152,7 @@ setTimeout(function(){
 				?>
 				var ipv4_status = '<?% echo ($ipv4_status); ?>';
 				var ipv6_status = '<?% echo ($ipv6_status); ?>';
-				var map_mode = '<?% echo (getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapTransportMode")); ?>';
+				var map_mode = '<?% echo (getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapTransportMode")); ?>';
 				if((ipv6_status == 'up' || ipv4_status == 'up')&& map_mode =='MAPT'){
 					$('#sta_inet').removeClass('off');
 				}

--- a/source/Styles/xb3/jst/includes/utility.jst
+++ b/source/Styles/xb3/jst/includes/utility.jst
@@ -1248,5 +1248,27 @@ function current_operationalMode()
         }
          return $selectedOperationalMode;
 }
-?>
 
+/**
+* Description:
+*  DHCP-manager will have individual DHCP client interfaces for each WAN interface.
+*  We have to identify the current active interface and use its DHCP interface details.
+* return the active DHCP client interfaces as JSON
+*/
+function get_dhcp_client_interfaces()
+{
+	var $dhcp_client_interfaces = { v4: "", v6: "" };
+	$ids = explode(",", getInstanceIds("Device.X_RDK_WanManager.Interface."));
+	wanInterfaceLoop: for($key in $ids) { $j = $ids[$key];
+		$status = getStr("Device.X_RDK_WanManager.Interface."+$j+".Status");
+		if($status == "true" || $status == "Up" || $status == "Active"){
+			$dhcp_client_interfaces.v4 = getStr("Device.X_RDK_WanManager.Interface."+$j+".VirtualInterface.1.IP.DHCPv4Interface");
+			$dhcp_client_interfaces.v6 = getStr("Device.X_RDK_WanManager.Interface."+$j+".VirtualInterface.1.IP.DHCPv6Interface");
+			break wanInterfaceLoop;
+		}
+	}
+	if($dhcp_client_interfaces.v4 == "") $dhcp_client_interfaces.v4 = "Device.DHCPv4.Client.1";
+	if($dhcp_client_interfaces.v6 == "") $dhcp_client_interfaces.v6 = "Device.DHCPv6.Client.1";
+	return $dhcp_client_interfaces;
+}
+?>

--- a/source/Styles/xb3/jst/local_ip_configuration.jst
+++ b/source/Styles/xb3/jst/local_ip_configuration.jst
@@ -24,7 +24,9 @@
 <?% include('includes/userbar.jst'); ?>
 </div><!-- end #sub-header -->
 <?% include('includes/nav.jst'); ?>
-<?% 
+<?%
+$dhcp_client_interfaces = get_dhcp_client_interfaces();
+$dhcp_client_interface_v4 = $dhcp_client_interfaces.v4;
 $device_ctrl_param = {
 	"LanGwIP"	: "Device.X_CISCO_COM_DeviceControl.LanManagementEntry.1.LanIPAddress",
 	"DeviceMode"	: "Device.X_CISCO_COM_DeviceControl.DeviceMode",
@@ -48,7 +50,7 @@ $ula_size = count($ula_v6_prefix_arr);
 //CM GW IP Address
 $CM_GW_IP_Address = getStr("Device.X_CISCO_COM_CableModem.Gateway");
 //WAN GW IP Address (IPv4)
-$WAN_GW_IPv4_Address =getStr("Device.DHCPv4.Client.1.IPRouters");
+$WAN_GW_IPv4_Address =getStr($dhcp_client_interface_v4+".IPRouters");
 //Virtual LAN_GW_IPv4_Address
 $LAN_GW_IPv4_Address = "";
 $out={};

--- a/source/Styles/xb3/jst/network_setup.jst
+++ b/source/Styles/xb3/jst/network_setup.jst
@@ -25,11 +25,14 @@
 </div><!-- end #sub-header -->
 <?% include('includes/nav.jst'); ?>
 <?%
+	$dhcp_client_interfaces = get_dhcp_client_interfaces();
+	$dhcp_client_interface_v4 = $dhcp_client_interfaces.v4;
+	$dhcp_client_interface_v6 = $dhcp_client_interfaces.v6;
 	$NetworkName = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.RDKB_UIBranding.HelpTip.NetworkName");
 	$wanType = get_wan_type();
 	$partnerId = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId");
 	$mapT ="";
-	$mapT = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
+	$mapT = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
 	$jsMapEnable="false";
 	$maptEnabled = "Disabled";
 	$maptSpanId = "disablespanid_mapt";
@@ -38,7 +41,7 @@
 		$maptEnabled = "Enabled";
 		$maptSpanId  = "enablespanid_mapt";
 	}
-	$maptRatio = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapRatio");
+	$maptRatio = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapRatio");
 	if (strpos($partnerId, "sky-") !== false) {
 		$maptRatio += ":1";
 	}
@@ -147,9 +150,9 @@ function sec2dhms($sec)
 	$sta_inet = (getStr("Device.DeviceInfo.X_RDKCENTRAL-COM.InternetStatus")=="true") ? "true" : "false";
 	//in Bridge mode > Internet connectivity status is always active
 	$sta_inet = ($_SESSION["lanMode"] == "bridge-static") ? "true" : $sta_inet ;
-	$WANIPv4Gateway = getStr("Device.DHCPv4.Client.1.IPRouters");
+	$WANIPv4Gateway = getStr($dhcp_client_interface_v4+".IPRouters");
 	if(strpos($partnerId, "sky-") !== false){
-		$isMapT = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
+		$isMapT = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
 		if($isMapT == 'MAPT'){
 		    /*$WANIPv4_val = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapRuleIPv4Prefix");
 		    $WANIPv4_val_array = explode('.',$WANIPv4_val);
@@ -158,7 +161,7 @@ function sec2dhms($sec)
                     $Add_val_int = intval($Add_val_int);
                     $WANIPv4_val_array[3]=$Convert_int+$Add_val_int;
                     $WANIPv4 = $WANIPv4_val_array[0]+'.'+$WANIPv4_val_array[1]+'.'+$WANIPv4_val_array[2]+'.'+$WANIPv4_val_array[3]+' (Shared using MAP-T)';*/
-		    $WANIPv4 = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
+		    $WANIPv4 = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
 		    $WANIPv4 += '<span id="shrdMpT_ns"> (Shared using MAP-T)</span>';
                     $WANIPv4Gateway = '-NA-';
 		}
@@ -313,7 +316,7 @@ function sec2dhms($sec)
 		<?%
 			//echo getStr("Device.Routing.Router.1.IPv4Forwarding.1.GatewayIPAddress");
 			/* For BWG, we just use the DHCP GW received from upstream as the wan side GW */
-			$wanDefaultGatewayAddressIPv4 = getStr("Device.DHCPv4.Client.1.IPRouters");
+			$wanDefaultGatewayAddressIPv4 = getStr($dhcp_client_interface_v4+".IPRouters");
 			if(get_mapt_status()) $wanDefaultGatewayAddressIPv4 = "NA";
 			if((strpos($partnerId, "sky-") !== false) && !$is_wan_connected) $wanDefaultGatewayAddressIPv4 = "0.0.0.0";
 			echo($wanDefaultGatewayAddressIPv4);
@@ -406,19 +409,19 @@ function sec2dhms($sec)
 	<div class="form-row ">
 		<span class="readonlyLabel" id="dhcliv6">DHCP Client (IPv6):</span>
 		<?%
-                        var idEnabled =("true"==getStr("Device.DHCPv6.Client.1.Enable")) ? "enablespanid" : "disablespanid";
+                        var idEnabled =("true"==getStr($dhcp_client_interface_v6+".Enable")) ? "enablespanid" : "disablespanid";
 		?>
 		 <span class="value" id="<?% echo(idEnabled); ?>">
-		<?% echo( ("true"==getStr("Device.DHCPv6.Client.1.Enable")) ? "Enabled" : "Disabled");?>
+		<?% echo( ("true"==getStr($dhcp_client_interface_v6+".Enable")) ? "Enabled" : "Disabled");?>
 		</span>
-	</div>	
+	</div>
 	<div class="form-row odd">
 		<span class="readonlyLabel" id="dhlease">DHCP Lease Expire Time (IPv4):</span>
 		<span class="value">
 		<?%
 			if(strpos($partnerId, "sky-") !== false){
 				if($Wan_Port_Status !="Disconnected"){
-					$sec = getStr("Device.DHCPv4.Client.1.LeaseTimeRemaining");
+					$sec = getStr($dhcp_client_interface_v4+".LeaseTimeRemaining");
 					$tmp = div_mod($sec, 24*60*60);
 					$day = $tmp[0];
 					$tmp = div_mod($tmp[1], 60*60);
@@ -428,7 +431,7 @@ function sec2dhms($sec)
 					echo( $day+"d:"+$hor+"h:"+$min+"m");
 				}
 			}else{
-				$sec = getStr("Device.DHCPv4.Client.1.LeaseTimeRemaining");
+				$sec = getStr($dhcp_client_interface_v4+".LeaseTimeRemaining");
 				$tmp = div_mod($sec, 24*60*60);
 				$day = $tmp[0];
 				$tmp = div_mod($tmp[1], 60*60);

--- a/source/Styles/xb3/jst/port_forwarding.jst
+++ b/source/Styles/xb3/jst/port_forwarding.jst
@@ -43,7 +43,9 @@ else{
 	$idadv = "connhom1";
 	$idadv2 = "portmess";
 }
-$mapT = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
+$dhcp_client_interfaces = get_dhcp_client_interfaces();
+$dhcp_client_interface_v6 = $dhcp_client_interfaces.v6;
+$mapT = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
 $partnerId = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId");
 $jsMapEnable="false";
 if(($mapT=="MAPT") && (strpos($partnerId, "sky-") === false)){

--- a/source/Styles/xb3/jst/port_triggering.jst
+++ b/source/Styles/xb3/jst/port_triggering.jst
@@ -28,8 +28,10 @@
 <?%
 $PTEnable=getStr("Device.NAT.X_CISCO_COM_PortTriggers.Enable");
 $partnerId = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId");
+$dhcp_client_interfaces = get_dhcp_client_interfaces();
+$dhcp_client_interface_v6 = $dhcp_client_interfaces.v6;
 $mapT ="";
-$mapT = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
+$mapT = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
 //$mapT = "MAPT";
 $jsMapEnable="false";
 if(($mapT=="MAPT") && (strpos($partnerId, "sky-") === false)){

--- a/source/Styles/xb3/jst/remote_management.jst
+++ b/source/Styles/xb3/jst/remote_management.jst
@@ -61,8 +61,10 @@ $http_port	= $DeviceControl_value['http_port'];
 $https_port	= $DeviceControl_value['https_port'];
 $ipv4_gw	= $DeviceControl_value['ipv4_gw'];
 $ipv4_smask	= $DeviceControl_value['ipv4_smask'];
+$dhcp_client_interfaces = get_dhcp_client_interfaces();
+$dhcp_client_interface_v6 = $dhcp_client_interfaces.v6;
 $mapT = "";
-$mapT = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
+$mapT = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
 $jsMapEnable="false";
 if(($mapT=="MAPT") && (strpos($partnerId, "sky-") === false)){
         $jsMapEnable = "true";
@@ -802,7 +804,7 @@ function remote_access_block(){
 				else{*/
 					echo('<span id="remmess1">Remote Management Address (IPv4):</span> ');
 					if($jsMapEnable == "true")
-						echo(getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapIpv4Address"));
+						echo(getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapIpv4Address"));
 					else
 						echo( getStr($fistUSif+"IPv4Address.1.IPAddress"));
 				//}

--- a/source/Styles/xb3/jst/wan_network.jst
+++ b/source/Styles/xb3/jst/wan_network.jst
@@ -26,6 +26,8 @@
 </div><!-- end #sub-header -->
 <?% include('includes/nav.jst'); ?>
 <?%
+	$dhcp_client_interfaces = get_dhcp_client_interfaces();
+	$dhcp_client_interface_v6 = $dhcp_client_interfaces.v6;
 	$modelName= getStr("Device.DeviceInfo.ModelName");
 	$autoWanEnable= getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_AutowanFeatureSupport");
 	$allowEthWan= getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.RDKB_UIBranding.AllowEthernetWAN");
@@ -35,7 +37,7 @@
 		die();
 	}
 	$mapT ="";
-	$mapT = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
+	$mapT = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
 	$partnerId = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId");
 	//$mapT = "MAPT";
 	$jsMapEnable="false";
@@ -44,7 +46,7 @@
 	}
 	$fistUSif = getFirstUpstreamIpInterface();
 	if($jsMapEnable == "true")
-		$WANIPv4 = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
+		$WANIPv4 = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
 	else
 		$WANIPv4 = getStr($fistUSif+"IPv4Address.1.IPAddress");
 	$WANIPv6= getStr("Device.DeviceInfo.X_COMCAST-COM_WAN_IPv6");

--- a/source/Styles/xb6/jst/connection_status_onewifi.jst
+++ b/source/Styles/xb6/jst/connection_status_onewifi.jst
@@ -27,6 +27,9 @@
 <?% include('includes/nav.jst'); ?>
 <?% $ForceDisable = getStr("Device.WiFi.X_RDK-CENTRAL_COM_ForceDisable"); ?>
 <?%
+	$dhcp_client_interfaces = get_dhcp_client_interfaces();
+	$dhcp_client_interface_v4 = $dhcp_client_interfaces.v4;
+	$dhcp_client_interface_v6 = $dhcp_client_interfaces.v6;
     $fistDSif = getFirstDownstreamIpInterface();
     $autoWanEnable= getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_AutowanFeatureSupport");
     $OperatingChannelBandwidth = "";
@@ -414,7 +417,7 @@ if(($allowEthWan=="true") || ($autoWanEnable=="true")) {
                             }else{
                             	echo('<span class="value" id="actautwan">Active Auto WAN');
                             }
-                          }          
+                          }
                          ?>
                     </span>
                 </div>
@@ -422,7 +425,7 @@ if(($allowEthWan=="true") || ($autoWanEnable=="true")) {
                     <span class="readonlyLabel" id="wanip4">WAN IP Address (IPv4):</span> <span class="value">
 		<?%
 			$mapT ="";
-			$mapT = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
+			$mapT = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
 			//$mapT = "MAPT";
 			$jsMapEnable="false";
 			$partnerId = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId");
@@ -430,7 +433,7 @@ if(($allowEthWan=="true") || ($autoWanEnable=="true")) {
 				$jsMapEnable = "true";
 			}
 			if($jsMapEnable == "true")
-				$WANIPv4 = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
+				$WANIPv4 = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
 			else
 				$WANIPv4 = getStr($fistUSif+"IPv4Address.1.IPAddress");
 			echo( $WANIPv4);
@@ -476,7 +479,7 @@ if(($allowEthWan=="true") || ($autoWanEnable=="true")) {
                       echo("<span class='value' id='act'>Active</span>");
                    }
                    else{
-                      echo("<span class='value' id='inact'>Inactive</span>"); 
+                      echo("<span class='value' id='inact'>Inactive</span>");
                    }
               }
             }
@@ -486,9 +489,9 @@ if(($allowEthWan=="true") || ($autoWanEnable=="true")) {
             $WAN_IP_Address = '';
             $address_style = '';
             if(strpos($partnerId, "sky-") !== false){
-                $isMapT = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
+                $isMapT = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
                 if($isMapT == 'MAPT'){
-		    $WANIPv4 = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
+		    $WANIPv4 = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
 		    $WANIPv4 += '<span id="shrdMpT_cs"> (Shared using MAP-T)</span>';
                     //$WANIPv4Gateway = '-NA-';
                     $WAN_IP_Address = $WANIPv4;
@@ -528,7 +531,7 @@ if(($allowEthWan=="true") || ($autoWanEnable=="true")) {
         <div class="form-row">
           <span class="readonlyLabel" id="dhcpexploc">DHCP Expire Time:</span> <span class="value">
                     <?%
-                    $expire_time = getStr("Device.DHCPv4.Client.1.LeaseTimeRemaining");
+                    $expire_time = getStr($dhcp_client_interface_v4+".LeaseTimeRemaining");
                     echo( sec2dhms($expire_time));
                     ?>
                 </span>

--- a/source/Styles/xb6/jst/network_setup.jst
+++ b/source/Styles/xb6/jst/network_setup.jst
@@ -25,20 +25,23 @@
 </div><!-- end #sub-header -->
 <?% include('includes/nav.jst'); ?>
 <?%
+	$dhcp_client_interfaces = get_dhcp_client_interfaces();
+	$dhcp_client_interface_v4 = $dhcp_client_interfaces.v4;
+	$dhcp_client_interface_v6 = $dhcp_client_interfaces.v6;
 	$NetworkName = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.RDKB_UIBranding.HelpTip.NetworkName");
 	$mapT ="";
-	$mapT = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
+	$mapT = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapTransportMode");
 	$jsMapEnable="false";
 	$maptEnabled = "Disabled";
 	if($mapT=="MAPT"){
         	$jsMapEnable = "true";
 		$maptEnabled = "Enabled";
 	}
-	$maptRatio = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapRatio");
+	$maptRatio = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapRatio");
 ?>
 <script type="text/javascript">
 $(document).ready(function() {
-   <?% if(is_device_router()) { ?> 
+   <?% if(is_device_router()) { ?>
 	gateway.page.init("Router > Connection > <?% echo( $NetworkName); ?>", "nav-gateway-network");
    <?% } else { ?>
 	gateway.page.init("Gateway > Connection > <?% echo( $NetworkName); ?>", "nav-gateway-network");
@@ -79,7 +82,7 @@ function sec2dhms($sec)
 	$partnerId = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId");
 	$fistUSif = getFirstUpstreamIpInterface();
 	if($jsMapEnable == "true")
-		$WANIPv4 = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
+		$WANIPv4 = getStr($dhcp_client_interface_v6+".X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
 	else
 		$WANIPv4 = getStr($fistUSif+"IPv4Address.1.IPAddress");
 	$ids = explode(",", getInstanceIds($fistUSif+"IPv6Address."));
@@ -270,7 +273,7 @@ function sec2dhms($sec)
 		<?%
 			//echo getStr("Device.Routing.Router.1.IPv4Forwarding.1.GatewayIPAddress");
 			/* For BWG, we just use the DHCP GW received from upstream as the wan side GW */
-			$wanDefaultGatewayAddressIPv4 = getStr("Device.DHCPv4.Client.1.IPRouters");
+			$wanDefaultGatewayAddressIPv4 = getStr($dhcp_client_interface_v4+".IPRouters");
 			if(get_mapt_status()) $wanDefaultGatewayAddressIPv4 = "NA";
 			if((strpos($partnerId, "sky-") !== false) && !$is_wan_connected) $wanDefaultGatewayAddressIPv4 = "0.0.0.0";
 			echo($wanDefaultGatewayAddressIPv4);
@@ -350,14 +353,14 @@ function sec2dhms($sec)
 	</div>
 	<div class="form-row ">
 		<span class="readonlyLabel">DHCP Client (IPv6):</span> <span class="value">
-		<?% echo( ("true"==getStr("Device.DHCPv6.Client.1.Enable")) ? "Enabled" : "Disabled");?>
+		<?% echo( ("true"==getStr($dhcp_client_interface_v6+".Enable")) ? "Enabled" : "Disabled");?>
 		</span>
-	</div>	
+	</div>
 	<div class="form-row odd">
 		<span class="readonlyLabel">DHCP Lease Expire Time (IPv4):</span>
 		<span class="value">
 		<?%
-			$sec = getStr("Device.DHCPv4.Client.1.LeaseTimeRemaining");
+			$sec = getStr($dhcp_client_interface_v4+".LeaseTimeRemaining");
 			$tmp = div_mod($sec, 24*60*60);
 			$day = $tmp[0];
 			$tmp = div_mod($tmp[1], 60*60);


### PR DESCRIPTION
Reason for change:
Incorrect MAP-T Sharing Ratio and Delegated IPv6 Prefix DHCP-manager will have individual DHCP client interfaces for each WAN interface. Identify the current active interface and use its DHCP interface details.

Test Procedure: Test for DHCP client details in GUI pages - DPoE.jst, connection_status.jst, device_discovery.jst, dmz.jst, local_ip_configuration.jst, network_setup.jst, port_forwarding.jst, port_triggering.jst, remote_management.jst, wan_network.jst

Risks: low
Priority: Major
Signed-off-by: pavankumarreddy_balireddy@comcast.com