### PR TITLE
RDKCOM-5370: RDKBDEV-3216 REFPLTB-3033 RDKBACCL-886  RDKBACCL-887 RDKBACCL-910 WAN Network' link not available on GateWay>Connecion page in RDKM admin UI

### DIFF
--- a/source/Styles/xb3/jst/connection_status.jst
+++ b/source/Styles/xb3/jst/connection_status.jst
@@ -425,7 +425,7 @@ if(($allowEthWan=="true") || ($autoWanEnable=="true")) {
                           }else{
                             $wan_enable= getStr("Device.Ethernet.X_RDKCENTRAL-COM_WAN.Enabled");
                             $modelName = getStr("Device.DeviceInfo.ModelName");
-                            if($modelName=="RPI"){
+                            if(($modelName=="RPI") || ($modelName=="BananapiBPI-R4")){
                                 if($wan_enable=="true"){
                                     echo('<span class="value" id="actethwan">Active Ethernet WAN');
                                 }

--- a/source/Styles/xb3/jst/includes/nav.jst
+++ b/source/Styles/xb3/jst/includes/nav.jst
@@ -184,7 +184,7 @@ echo( '<li class="nav-gateway">');
 		if ($MoCA) {
 		  echo( '<li class="nav-moca"><a role="menuitem"  href="moca.jst">MoCA</a></li>');
 		}
-		if((($autoWanEnable=="true") || ($allowEthWan=="true")) && (($modelName=="CGM4140COM") || ($modelName=="CGM4331COM") || ($modelName=="CGM4981COM") || ($modelName=="TG4482A"))){
+		if((($autoWanEnable=="true") || ($allowEthWan=="true")) && (($modelName=="CGM4140COM") || ($modelName=="CGM4331COM") || ($modelName=="CGM4981COM") || ($modelName=="TG4482A") || ($modelName=="RPI") || ($modelName=="BananapiBPI-R4"))){
 			if($wan_network) echo( '<li class="nav-wan-network"><a role="menuitem"  href="wan_network.jst" id="wannet">WAN Network</a></li>');
 		}
 		echo( '</ul>');

--- a/source/Styles/xb3/jst/network_setup.jst
+++ b/source/Styles/xb3/jst/network_setup.jst
@@ -866,7 +866,7 @@ if ($wanType == "DSL") {
   if(!$CM_value["CoreVersion"]){ $CM_value["CoreVersion"] = 'NA';}
 }?>
 <!-- Updating the CoreVersion value as 'NA' for RPI -->
-<?% if($device_value["ModelName"]=="RPI"){
+<?% if(($device_value["ModelName"]=="RPI") || ($device_value["ModelName"]=="BananapiBPI-R4")){
   if(!$CM_value["CoreVersion"]){ $CM_value["CoreVersion"] = 'NA';}
 }?>
 <div class="module forms">

--- a/source/Styles/xb3/jst/wan_network.jst
+++ b/source/Styles/xb3/jst/wan_network.jst
@@ -33,7 +33,7 @@
 	$allowEthWan= getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.RDKB_UIBranding.AllowEthernetWAN");
 	$wanPort= getStr("Device.Ethernet.X_RDKCENTRAL-COM_WAN.Port");
 	$portNo= parseInt($wanPort)+1;
-	if(!((($autoWanEnable=="true") || ($allowEthWan=="true")) && (($modelName=="CGM4140COM") || ($modelName=="CGM4331COM") || ($modelName=="CGM4981COM") || ($modelName=="SG417DBCT") || ($modelName=="CGM601TCOM") || ($modelName=="TG4482A") || ($modelName=="RPI"))) ){
+	if(!((($autoWanEnable=="true") || ($allowEthWan=="true")) && (($modelName=="CGM4140COM") || ($modelName=="CGM4331COM") || ($modelName=="CGM4981COM") || ($modelName=="SG417DBCT") || ($modelName=="CGM601TCOM") || ($modelName=="TG4482A") || ($modelName=="RPI") || ($modelName=="BananapiBPI-R4"))) ){
 		die();
 	}
 	$mapT ="";


### PR DESCRIPTION
Reason for change: Added modelName for both RPI and BPI platforms Test Procedure:
1.WAN Network link page should open properly in admin UI page. 
2.Wan Network Status should be 'Active Ethernet WAN' in Connection> Status Page. 
3.Core Version should be NA in 'Gateway > Connection > RDKM' page in UI. 
Risks: Low