### PR TITLE
RDKB-61544: Default Start from Time is showing "PM"

### DIFF
--- a/source/Styles/xb3/jst/managed_sites.jst
+++ b/source/Styles/xb3/jst/managed_sites.jst
@@ -711,9 +711,10 @@ $.validator.addMethod("no_space", function(value, element, param) {
     if($blockedInfo['AlwaysBlock']=="true"){
     	$rel_st_hour = 12;
     	$st_min ="00";
+        $st_hour = 0;
     	$rel_end_hour = 11;
     	$end_min ="59";
-	$end_hour = 13;
+    	$end_hour = 13;
     }
     $block_days = $blockedInfo['BlockedDays'];
 	if(strpos($partnerId, "sky-") !== false){


### PR DESCRIPTION
RDKB-61544: Default Start from Time is showing "PM"

Reason for change: Default Start from Time is showing "PM" when Always-Block option Disabled

Test Procedure: Add Blocked Site/keyword with ALways block option

Risks:low
Priority: P1
Signed-off-by: pavankumarreddy_balireddy@comcast.com