### PR TITLE
RDKB-61788 : Input elements blocked in WebUI can be bypassed in HCM mode

### DIFF
--- a/source/Styles/xb6/jst/actionHandler/ajaxSet_wireless_network_configuration_edit.jst
+++ b/source/Styles/xb6/jst/actionHandler/ajaxSet_wireless_network_configuration_edit.jst
@@ -33,6 +33,7 @@ $partnerId = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId");
 $Mesh_Enable 	= getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.Mesh.Enable");
 $Mesh_State 	= getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.Mesh.State");
 $Mesh_Mode = ($Mesh_Enable == 'true' && $Mesh_State == 'Full')? true : false;
+$HCM_Mode = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MeshWifiOptimization.Mode");
 $OperatingChannelBandwidth ="";
 $RadioNumberOfEntries = getStr("Device.WiFi.RadioNumberOfEntries");
 if($RadioNumberOfEntries)
@@ -116,6 +117,7 @@ function security_mode($encrypt_mode, $encrypt_method) {
 }
 
 if($i != 1 && $i != 2 && $i != 17) $Mesh_Mode = false;
+if($i != 1 && $i != 2 && $i != 17) $HCM_Mode = "Disable";
 $response_message = '';
 //ssid 1,2 for all
 //ssid 3,4 for mso only
@@ -133,7 +135,7 @@ if ($i == 1 || $i == 2 || $i == 17) {
 			}
 		}
 		setStr("Device.WiFi.SSID."+$i+".Enable", $arConfig['radio_enable'], true);
-		if ("true" == $arConfig['radio_enable'] && (!$Mesh_Mode) )
+		if ("true" == $arConfig['radio_enable'] && (!$Mesh_Mode) && ($HCM_Mode != "Enable"))
 		{
 			$validation = true;
 			if(($arConfig['password_update']=="false") && ("mso" == $thisUser)){

--- a/source/Styles/xb6/jst/actionHandler/ajaxSet_wireless_network_configuration_edit_onewifi.jst
+++ b/source/Styles/xb6/jst/actionHandler/ajaxSet_wireless_network_configuration_edit_onewifi.jst
@@ -33,6 +33,7 @@ $partnerId = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId");
 $Mesh_Enable 	= getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.Mesh.Enable");
 $Mesh_State 	= getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.Mesh.State");
 $Mesh_Mode = ($Mesh_Enable == 'true' && $Mesh_State == 'Full')? true : false;
+$HCM_Mode = getStr("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MeshWifiOptimization.Mode");
 $OperatingChannelBandwidth ="";
 $RadioNumberOfEntries = getStr("Device.WiFi.RadioNumberOfEntries");
 if($RadioNumberOfEntries)
@@ -120,6 +121,7 @@ function security_mode($encrypt_mode, $encrypt_method) {
 }
 
 if($i != 1 && $i != 2 && $i != 17) $Mesh_Mode = false;
+if($i != 1 && $i != 2 && $i != 17) $HCM_Mode = "Disable";
 $response_message = '';
 //ssid 1,2 for all
 //ssid 3,4 for mso only
@@ -137,7 +139,7 @@ if ($i == 1 || $i == 2 || $i == 17) {
 			}
 		}
 		setStr("Device.WiFi.SSID."+$i+".Enable", $arConfig['radio_enable'], true);
-		if ("true" == $arConfig['radio_enable'] && (!$Mesh_Mode) )
+		if ("true" == $arConfig['radio_enable'] && (!$Mesh_Mode) && ($HCM_Mode != "Enable"))
 		{
 			$validation = true;
 			if(($arConfig['password_update']=="false") && ("mso" == $thisUser)){


### PR DESCRIPTION
Reason for change: Added checks in ajax to prevent updates wireless
                   config updates when in HCM mode.
Test Procedure: Refer ticket

Change-Id: If683533a99d3f0f50d6b77a9b95a82c53bb6c4f8
Priority: P1
Risks: Medium