### PR TITLE
RDKB-60389: WAN IP Address (IPv4) is incorrect for MAP-T in Network page

### DIFF
--- a/source/Styles/xb6/jst/network_setup.jst
+++ b/source/Styles/xb6/jst/network_setup.jst
@@ -154,6 +154,11 @@ function sec2dhm($sec)
 	//in Bridge mode > Internet connectivity status is always active
 	$sta_inet = ($_SESSION["lanMode"] == "bridge-static") ? "true" : $sta_inet ;
 
+        if($mapT == 'MAPT'){
+                 $WANIPv4 = getStr("Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapIpv4Address");
+                 $WANIPv4 += '<span id="shrdMpT_ns"> (Shared using MAP-T)</span>';
+	}
+
 	//WAN details Fetching
 	$wan_Interface_obj = "Device.IP.Interface.";
 	$wan_Interface_ids =  DmExtGetInstanceIds($wan_Interface_obj);


### PR DESCRIPTION
Reason for change: WAN IP Address (IPv4) is incorrect for MAP-T in Network page
Test Procedure: Build and verify in GUI page
Risks: Low
Priority: P2

Change-Id: I20190a0db5fdec3040a9b6770ad21bc17bb7152a

(cherry picked from commit 97c219b1985fb07189a5431ed2971ccd0dab1ace)