### PR TITLE
RDKB-62863: WiFi ready page is missing in captive portal

### DIFF
--- a/source/Styles/xb3/jst/captiveportal.jst
+++ b/source/Styles/xb3/jst/captiveportal.jst
@@ -367,9 +367,6 @@ $(document).ready(function(){
 							location.href="index.jst";
 						}, 10000);
 					}
-					if(connectionType != "WiFi"){
-						setTimeout(function(){ goToReady(); }, 25000);
-					}
 				},
 				error: function(xhr, status, error) {
 					// Handle error
@@ -388,6 +385,9 @@ $(document).ready(function(){
 			});
 		}
 		postConfig();
+		if(connectionType != "WiFi"){
+			setTimeout(function(){ goToReady(); }, 25000);
+		}
 	}
 	var NameTimeout, PasswordTimeout, Name5Timeout, Password5Timeout, phoneNumberTimeout, agreementTimeout;
 	function messageHandler(target, topMessage, bottomMessage){


### PR DESCRIPTION
Reason for change: WiFi ready page is missing in captive portal after a Factory reset in 8.2x

Test Procedure: Test for captive portal

Risks:low
Priority: P1
Signed-off-by: pavankumarreddy_balireddy@comcast.com