### PR TITLE
RDKCOM-5598: RDKBDEV-3451, RDKBACCL-1834 Security mode shows WPAWPA2-PSK (TKIP/AES) on Web-UI upon changing to WPA3-Enterprise via dmcli

### DIFF
--- a/source/Styles/xb3/jst/includes/utility.jst
+++ b/source/Styles/xb3/jst/includes/utility.jst
@@ -122,6 +122,8 @@ function encrypt_map($mode, $method)
 			return "WPA3-Personal Transition";
 		case "WPA3-Personal-Compatibility":
 			return "WPA3-Personal Compatibility";
+		case "WPA3-Enterprise":
+			return "WPA3-Enterprise";
 		default:
 			return "WPAWPA2-PSK (TKIP/AES)";
 	}
@@ -167,6 +169,9 @@ function security_mode_map($encrypt_mode, $encrypt_method)
 	}
 	else if ("WPA3-Personal-Compatibility" == $encrypt_mode){
 		$security = "WPA3-Personal Compatibility";
+	}
+	else if ("WPA3-Enterprise" == $encrypt_mode){
+		$security = "WPA3-Enterprise";
 	}
 	return $security;
 }

--- a/source/Styles/xb6/jst/wireless_network_configuration_edit_onewifi.jst
+++ b/source/Styles/xb6/jst/wireless_network_configuration_edit_onewifi.jst
@@ -1173,6 +1173,11 @@ function setResetInfo(info) {
                                 <option value="WPA3-Personal Compatibility"  <?% if ("WPA3-Personal Compatibility"==$security) echo( "selected");?> >WPA3-Personal Compatibility (Recommended)</option>
 				<option value="WPA3-Personal Only" id="secmode4" title="WPA requires an 8-63 ASCII character password or a 64 hex character password. Hex means only the following characters can be used: ABCDEF0123456789." <?% if ("WPA3-Personal Only"==$security)  echo( "selected");?> >WPA3-Personal Only</option>
                                 <?%
+                                }else if($WPA3_enable == "true" && $encrypt_mode == "WPA3-Enterprise"){
+                                ?>
+                                <option value="WPA3-Personal Only" id="secmode4" title="WPA requires an 8-63 ASCII character password or a 64 hex character password. Hex means only the following characters can be used: ABCDEF0123456789." <?% if ("WPA3-Personal Only"==$security)  echo( "selected");?> >WPA3-Personal Only</option>
+                                <option value="WPA3-Enterprise"  <?% if ("WPA3-Enterprise"==$security) echo( "selected");?> >WPA3-Enterprise</option>
+                                 <?%
                                  } else {
                                 ?>
                                 <option value="WPA3-Personal Only" id="secmode4" title="WPA requires an 8-63 ASCII character password or a 64 hex character password. Hex means only the following characters can be used: ABCDEF0123456789." <?% if ("WPA3-Personal Only"==$security)  echo( "selected");?> >WPA3-Personal Only</option>
@@ -1193,6 +1198,13 @@ function setResetInfo(info) {
 				}else if($WPA3_compatibility_enable == "true"){
                                 ?>
                                 <option value="WPA3-Personal Compatibility"  <?% if ("WPA3-Personal Compatibility"==$security) echo( "selected");?> >WPA3-Personal Compatibility (Recommended)</option>
+                                <option value="WPA2_PSK_AES" id="secmode4" title="WPA requires an 8-63 ASCII character password or a 64 hex character password. Hex means only the following characters can be used: ABCDEF0123456789." <?% if ("WPA2_PSK_AES"==$security)        echo( "selected");?> >WPA2-PSK (AES)</option>
+                                <?%
+				}else if($WPA3_enable == "true" && $encrypt_mode == "WPA3-Enterprise"){
+                                ?>
+                                <option value="WPA3-Personal Transition"  <?% if ("WPA3-Personal Transition"==$security) echo( "selected");?> >WPA3-Personal Transition (Recommended)</option>
+                                <option value="WPA3-Personal Only"  <?% if ("WPA3-Personal Only"==$security) echo( "selected");?> >WPA3-Personal Only</option>
+                                <option value="WPA3-Enterprise"  <?% if ("WPA3-Enterprise"==$security) echo( "selected");?> >WPA3-Enterprise</option>
                                 <option value="WPA2_PSK_AES" id="secmode4" title="WPA requires an 8-63 ASCII character password or a 64 hex character password. Hex means only the following characters can be used: ABCDEF0123456789." <?% if ("WPA2_PSK_AES"==$security)        echo( "selected");?> >WPA2-PSK (AES)</option>
                                 <?%
                                 }else if($WPA3_enable == "true"){


### PR DESCRIPTION
Reason for Change: Added WPA3-Enterprise option in the encrypt_map() function to ensure the WebUI displays the correct security mode instead of the default(WPAWPA2-PSK) value.
Test Procedure: Configure Device.WiFi.AccessPoint.*.Security.ModeEnabled to WPA3-Enterprise via DMCLI and verify the same from WebUI for 2G, 5G and 6G.
Risks: Low.