### PR TITLE
RDK-61615: Remove Sensitive StringFrom Open Source

### DIFF
--- a/source/Styles/xb3/config/webgui.sh
+++ b/source/Styles/xb3/config/webgui.sh
@@ -68,7 +68,7 @@ fi
 if [ "x$BOX_TYPE" != "xrpi" ] && [ "x$BOX_TYPE" != "xbpi" ] && [ "x$BOX_TYPE" != "xturris" ] && [ "x$BOX_TYPE" != "xemulator" ]; then
 #upstreamed webgui_script_https_support.patch to Secure webui redirection as part of RDKB-42686.
 mkdir -p /tmp/.webui/
-ID="/tmp/trpfizyanrln"
+ID="/tmp/myrouter-webui"
 itr=0
 
 while [ $itr -le 10 ]
@@ -97,7 +97,7 @@ else
 fi
 
 done
-if [ ! -f /tmp/trpfizyanrln ];then
+if [ ! -f /tmp/myrouter-webui ];then
 	echo "Error: Lighttpd key is not generated"
 	exit 1
 fi


### PR DESCRIPTION
Reason for change: Remove Sensitive String (pattern180) From Open Source
Test Procedure: Tested the tasks locally
Risks: Low
Signed-off-by: Aruna_Appikatla@comcast.com